### PR TITLE
Only restart bitcoind when pid file is not present

### DIFF
--- a/bitcoind.rb
+++ b/bitcoind.rb
@@ -67,7 +67,13 @@ class Bitcoind < Formula
         <key>RunAtLoad</key>
         <true/>
         <key>KeepAlive</key>
-        <true/>
+        <dict>
+          <key>PathState</key>
+          <dict>
+            <key>~/Library/Application Support/Bitcoin/bitcoind.pid</key>
+            <false/>
+          </dict>
+        </dict>
         <key>ProgramArguments</key>
         <array>
           <string>#{opt_prefix}/bin/bitcoind</string>


### PR DESCRIPTION
The current configuration keeps polluting the debug.log file every 10 seconds. With this fix, it will only try to start the daemon when pid file is not present. See Apple documentation: https://developer.apple.com/library/mac/documentation/Darwin/Reference/Manpages/man5/launchd.plist.5.html
