### PR TITLE
bitcoind formula cleanup

### DIFF
--- a/bitcoind.rb
+++ b/bitcoind.rb
@@ -17,12 +17,18 @@ class Bitcoind < Formula
   depends_on "miniupnpc" => :optional
   deprecated_option "with-upnp" => "with-miniupnpc"
 
+  option "with-gui", "Build GUI client (requires Qt)"
+  if build.with? "gui"
+    depends_on "qt"
+    depends_on "protobuf"
+    depends_on "libqrencode"
+  end
+
   option "without-check", "Disable build-time checking"
 
   def install
     system "sh", "autogen.sh"
-    # todo: make --without-qt optional
-    system "./configure", "--prefix=#{prefix}", "--without-qt"
+    system "./configure", "--prefix=#{prefix}"
     system "make"
     system "make", "check" if build.with? "check"
 
@@ -30,6 +36,11 @@ class Bitcoind < Formula
     system "strip src/bitcoind"
     bin.install "src/bitcoin-cli"
     bin.install "src/bitcoind"
+
+    if build.with? "gui"
+      system "strip", "src/qt/bitcoin-qt"
+      bin.install "src/qt/bitcoin-qt"
+    end
   end
 
   def plist; <<-EOS.undent

--- a/bitcoind.rb
+++ b/bitcoind.rb
@@ -6,13 +6,14 @@ class Bitcoind < Formula
   version '0.10.0'
   head 'https://github.com/bitcoin/bitcoin.git', :branch => 'master'
 
-  depends_on 'automake'
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
   depends_on 'berkeley-db4'
   depends_on 'boost'
   depends_on 'miniupnpc' if build.include? 'with-upnp'
   depends_on 'openssl'
-  depends_on 'pkg-config'
-  depends_on 'protobuf'
 
   def install
     system "sh", "autogen.sh"

--- a/bitcoind.rb
+++ b/bitcoind.rb
@@ -17,11 +17,15 @@ class Bitcoind < Formula
   depends_on "miniupnpc" => :optional
   deprecated_option "with-upnp" => "with-miniupnpc"
 
+  option "without-check", "Disable build-time checking"
+
   def install
     system "sh", "autogen.sh"
     # todo: make --without-qt optional
     system "./configure", "--prefix=#{prefix}", "--without-qt"
     system "make"
+    system "make", "check" if build.with? "check"
+
     system "strip src/bitcoin-cli"
     system "strip src/bitcoind"
     bin.install "src/bitcoin-cli"

--- a/bitcoind.rb
+++ b/bitcoind.rb
@@ -29,7 +29,7 @@ class Bitcoind < Formula
   option "without-check", "Disable build-time checking"
 
   def install
-    system "sh", "autogen.sh"
+    system "./autogen.sh"
 
     args = []
     args << "--without-miniupnpc" if build.without? "miniupnpc"
@@ -40,17 +40,19 @@ class Bitcoind < Formula
     system "make"
     system "make", "check" if build.with? "check"
 
-    system "strip", "src/bitcoind"
-    bin.install "src/bitcoind"
+    cd "src" do
+      system "strip", "bitcoind"
+      bin.install "bitcoind"
 
-    if build.with? "utils"
-      system "strip", "src/bitcoin-cli", "src/bitcoin-tx"
-      bin.install "src/bitcoin-cli", "src/bitcoin-tx"
-    end
+      if build.with? "utils"
+        system "strip", "bitcoin-cli", "bitcoin-tx"
+        bin.install "bitcoin-cli", "bitcoin-tx"
+      end
 
-    if build.with? "gui"
-      system "strip", "src/qt/bitcoin-qt"
-      bin.install "src/qt/bitcoin-qt"
+      if build.with? "gui"
+        system "strip", "qt/bitcoin-qt"
+        bin.install "qt/bitcoin-qt"
+      end
     end
   end
 

--- a/bitcoind.rb
+++ b/bitcoind.rb
@@ -12,8 +12,10 @@ class Bitcoind < Formula
   depends_on "pkg-config" => :build
   depends_on 'berkeley-db4'
   depends_on 'boost'
-  depends_on 'miniupnpc' if build.include? 'with-upnp'
   depends_on 'openssl'
+
+  depends_on "miniupnpc" => :optional
+  deprecated_option "with-upnp" => "with-miniupnpc"
 
   def install
     system "sh", "autogen.sh"

--- a/bitcoind.rb
+++ b/bitcoind.rb
@@ -28,7 +28,12 @@ class Bitcoind < Formula
 
   def install
     system "sh", "autogen.sh"
-    system "./configure", "--prefix=#{prefix}"
+
+    args = []
+    args << "--without-miniupnpc" if build.without? "miniupnpc"
+    args << "--without-gui" if build.without? "gui"
+    system "./configure", "--prefix=#{prefix}", *args
+
     system "make"
     system "make", "check" if build.with? "check"
 

--- a/bitcoind.rb
+++ b/bitcoind.rb
@@ -17,6 +17,8 @@ class Bitcoind < Formula
   depends_on "miniupnpc" => :optional
   deprecated_option "with-upnp" => "with-miniupnpc"
 
+  option "without-utils", "Build without utilities (bitcoin-cli & bitcoin-tx)"
+
   option "with-gui", "Build GUI client (requires Qt)"
   if build.with? "gui"
     depends_on "qt"
@@ -31,16 +33,20 @@ class Bitcoind < Formula
 
     args = []
     args << "--without-miniupnpc" if build.without? "miniupnpc"
+    args << "--without-utils" if build.without? "utils"
     args << "--without-gui" if build.without? "gui"
     system "./configure", "--prefix=#{prefix}", *args
 
     system "make"
     system "make", "check" if build.with? "check"
 
-    system "strip src/bitcoin-cli"
-    system "strip src/bitcoind"
-    bin.install "src/bitcoin-cli"
+    system "strip", "src/bitcoind"
     bin.install "src/bitcoind"
+
+    if build.with? "utils"
+      system "strip", "src/bitcoin-cli", "src/bitcoin-tx"
+      bin.install "src/bitcoin-cli", "src/bitcoin-tx"
+    end
 
     if build.with? "gui"
       system "strip", "src/qt/bitcoin-qt"

--- a/bitcoind.rb
+++ b/bitcoind.rb
@@ -1,18 +1,15 @@
-require 'formula'
-
 class Bitcoind < Formula
-  homepage 'https://bitcoin.org/'
-  url 'https://github.com/bitcoin/bitcoin.git', :tag => 'v0.10.0'
-  version '0.10.0'
-  head 'https://github.com/bitcoin/bitcoin.git', :branch => 'master'
+  homepage "https://bitcoin.org/"
+  url "https://github.com/bitcoin/bitcoin.git", :tag => "v0.10.0"
+  head "https://github.com/bitcoin/bitcoin.git", :branch => "master"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on 'berkeley-db4'
-  depends_on 'boost'
-  depends_on 'openssl'
+  depends_on "berkeley-db4"
+  depends_on "boost"
+  depends_on "openssl"
 
   depends_on "miniupnpc" => :optional
   deprecated_option "with-upnp" => "with-miniupnpc"
@@ -93,5 +90,3 @@ class Bitcoind < Formula
     EOS
   end
 end
-
-__END__


### PR DESCRIPTION
Main highlights:
* Fix missing libtool build dependency (current formula fails with `autoreconf: glibtoolize is needed because this package uses Libtool`)
* Remove unnecessary dependency requirements
* Add option to build Qt client
* Install bitcoin-tx
* Add option to not build utils
* Make sure upnp support isn't built unless specifically enabled
* Add "make check" to build
* General formula style housekeeping
